### PR TITLE
Allow an interface to extend DataClass.

### DIFF
--- a/src/dataclass/macros/Builder.hx
+++ b/src/dataclass/macros/Builder.hx
@@ -245,45 +245,47 @@ class Builder
 			
 			if (val != null) assignments.push(val);
 		};
-		
-		var constructor = fields.find(function(f) return f.name == "new");
-		
-		if (constructor == null) {
-			var allOptional = ![for (f in fieldMap) f].exists(function(f) return f.opt == false);
-			
-			// Call parent constructor if it exists
-			if (cls.superClass != null)	assignments.unshift(macro super(data));
-			
-			// If all fields are optional, create a default argument assignment
-			if (allOptional) assignments.unshift(macro if (data == null) data = {});
-				
-			fields.push({
-				pos: cls.pos,
-				name: 'new',
-				meta: [],
-				kind: FFun({
-					ret: null,
-					params: [],
-					expr: {expr: EBlock(assignments), pos: cls.pos},
-					args: [{
-						value: null,
-						type: TAnonymous(publicFields),
-						opt: allOptional,
-						name: 'data'
-					}]
-				}),
-				doc: null,
-				access: [APublic]
-			});
-		} else {
-			switch constructor.kind {
-				case FFun(f):
-					switch f.expr.expr {
-						case EBlock(exprs): f.expr.expr = EBlock(assignments.concat(exprs));
-						case _: f.expr.expr = EBlock(assignments.concat([f.expr]));
-					}
-				case _: 
-					Context.error("Invalid constructor.", constructor.pos);
+
+		if (!cls.isInterface) {
+			var constructor = fields.find(function(f) return f.name == "new");
+
+			if (constructor == null) {
+				var allOptional = ![for (f in fieldMap) f].exists(function(f) return f.opt == false);
+
+				// Call parent constructor if it exists
+				if (cls.superClass != null)	assignments.unshift(macro super(data));
+
+				// If all fields are optional, create a default argument assignment
+				if (allOptional) assignments.unshift(macro if (data == null) data = {});
+
+				fields.push({
+					pos: cls.pos,
+					name: 'new',
+					meta: [],
+					kind: FFun({
+						ret: null,
+						params: [],
+						expr: {expr: EBlock(assignments), pos: cls.pos},
+						args: [{
+							value: null,
+							type: TAnonymous(publicFields),
+							opt: allOptional,
+							name: 'data'
+						}]
+					}),
+					doc: null,
+					access: [APublic]
+				});
+			} else {
+				switch constructor.kind {
+					case FFun(f):
+						switch f.expr.expr {
+							case EBlock(exprs): f.expr.expr = EBlock(assignments.concat(exprs));
+							case _: f.expr.expr = EBlock(assignments.concat([f.expr]));
+						}
+					case _:
+						Context.error("Invalid constructor.", constructor.pos);
+				}
 			}
 		}
 

--- a/tests/Tests.hx
+++ b/tests/Tests.hx
@@ -126,6 +126,10 @@ class Ignore implements dataclass.DataClass {
 	public var name : String;	
 }
 
+interface ExtendingInterface extends DataClass
+{
+}
+
 @:build(buddy.GenerateMain.withSuites([
 	Tests,
 	ConverterTests


### PR DESCRIPTION
I'm working on a lib that will use a marker interface, which I'd like to extend DataClass (to enforce that implementing classes must be simple data classes).

This patch just guards against adding a constructor field to a class if it's really an interface.
